### PR TITLE
Remove github.com/pkg/errors

### DIFF
--- a/gir/cmd/gir_generate/genutil/genutil.go
+++ b/gir/cmd/gir_generate/genutil/genutil.go
@@ -17,7 +17,6 @@ import (
 	"github.com/diamondburned/gotk4/gir"
 	"github.com/diamondburned/gotk4/gir/cmd/gir_generate/gendata"
 	"github.com/diamondburned/gotk4/gir/girgen"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -97,7 +96,7 @@ func WriteNamespace(ng *girgen.NamespaceGenerator, basePath string) error {
 	}
 
 	if err := os.MkdirAll(dir, 0777); err != nil {
-		return errors.Wrapf(err, "failed to mkdir -p %q", dir)
+		return fmt.Errorf("failed to mkdir -p %q: %w", dir, err)
 	}
 
 	files, err := ng.Generate()
@@ -105,7 +104,7 @@ func WriteNamespace(ng *girgen.NamespaceGenerator, basePath string) error {
 	for name, file := range files {
 		dst := filepath.Join(dir, name)
 		if err := os.WriteFile(dst, file, 0666); err != nil {
-			return errors.Wrapf(err, "failed to write to %s", dst)
+			return fmt.Errorf("failed to write to %s: %w", dst, err)
 		}
 	}
 
@@ -146,7 +145,7 @@ func AddPackages(repos *gir.Repositories, pkgs []gendata.Package) error {
 		}
 
 		if err != nil {
-			return errors.Wrapf(err, "error adding package %q", pkg.PkgName)
+			return fmt.Errorf("error adding package %q: %w", pkg.PkgName, err)
 		}
 	}
 
@@ -289,7 +288,7 @@ func CleanDirectory(path string, except []string) error {
 
 		fullPath := filepath.Join(path, oldFile.Name())
 		if err := os.RemoveAll(fullPath); err != nil {
-			return errors.Wrapf(err, "failed to rm -rf %s", oldFile)
+			return fmt.Errorf("failed to rm -rf %s: %w", oldFile, err)
 		}
 	}
 
@@ -312,18 +311,18 @@ func appendGoFile(path, filename, content string) error {
 
 	b, err := os.ReadFile(fullPath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read file %q", filename)
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 
 	b = append(b, []byte(content)...)
 
 	b, err = format.Source(b)
 	if err != nil {
-		return errors.Wrapf(err, "failed to go fmt file %q", filename)
+		return fmt.Errorf("failed to go fmt file %q: %w", filename, err)
 	}
 
 	if err := os.WriteFile(fullPath, b, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "failed to write file %q", filename)
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
 	}
 
 	return nil
@@ -336,7 +335,7 @@ func EnsureDirectory(path string, expects ...[]string) error {
 
 	files, err := os.ReadDir(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to read dir")
+		return fmt.Errorf("failed to read dir: %w", err)
 	}
 
 	for _, file := range files {

--- a/gir/gir.go
+++ b/gir/gir.go
@@ -15,7 +15,6 @@ import (
 	"unicode"
 
 	"github.com/diamondburned/gotk4/gir/pkgconfig"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -142,13 +141,13 @@ func (repos *Repositories) AddSelected(pkg string, wantedNames []string) error {
 
 	girs, err := pkgconfig.FindGIRFiles(pkg)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get gir files for %q", pkg)
+		return fmt.Errorf("failed to get gir files for %q: %w", pkg, err)
 	}
 
 	for _, gir := range girs {
 		repo, err := ParseRepository(gir)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse file %q", gir)
+			return fmt.Errorf("failed to parse file %q: %w", gir, err)
 		}
 
 		if !filter(repo) {
@@ -156,7 +155,7 @@ func (repos *Repositories) AddSelected(pkg string, wantedNames []string) error {
 		}
 
 		if err := repos.add(*repo, pkg, gir); err != nil {
-			return errors.Wrapf(err, "failed to add file %q", gir)
+			return fmt.Errorf("failed to add file %q: %w", gir, err)
 		}
 	}
 
@@ -172,17 +171,17 @@ func (repos *Repositories) AddSelected(pkg string, wantedNames []string) error {
 func (repos *Repositories) Add(pkg string) error {
 	girs, err := pkgconfig.FindGIRFiles(pkg)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get gir files for %q", pkg)
+		return fmt.Errorf("failed to get gir files for %q: %w", pkg, err)
 	}
 
 	for _, gir := range girs {
 		repo, err := ParseRepository(gir)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse file %q", gir)
+			return fmt.Errorf("failed to parse file %q: %w", gir, err)
 		}
 
 		if err := repos.add(*repo, pkg, gir); err != nil {
-			return errors.Wrapf(err, "failed to add file %q", gir)
+			return fmt.Errorf("failed to add file %q: %w", gir, err)
 		}
 	}
 

--- a/gir/girgen/file.go
+++ b/gir/girgen/file.go
@@ -13,7 +13,6 @@ import (
 	"github.com/diamondburned/gotk4/gir/girgen/logger"
 	"github.com/diamondburned/gotk4/gir/girgen/pen"
 	"github.com/diamondburned/gotk4/gir/girgen/types"
-	"github.com/pkg/errors"
 )
 
 // FileGenerator is a file generator.
@@ -160,7 +159,7 @@ func (f *FileGenerator) Generate() ([]byte, error) {
 	b, err := format.Source(fpen.Bytes())
 	if err != nil {
 		f.Logln(logger.Error, "fmt error:", err)
-		return fpen.Bytes(), errors.Wrap(err, "fmt error")
+		return fpen.Bytes(), fmt.Errorf("fmt error: %w", err)
 	}
 
 	return b, nil

--- a/gir/girgen/namespace.go
+++ b/gir/girgen/namespace.go
@@ -11,7 +11,6 @@ import (
 	"github.com/diamondburned/gotk4/gir/girgen/generators/iface"
 	"github.com/diamondburned/gotk4/gir/girgen/logger"
 	"github.com/diamondburned/gotk4/gir/girgen/types"
-	"github.com/pkg/errors"
 )
 
 // Postprocessor describes a processor function that modifies a namespace. It is
@@ -314,7 +313,7 @@ importedCgo:
 		files[name] = b
 
 		if err != nil && firstErr == nil {
-			firstErr = errors.Wrapf(err, "%s/v%s/%s", n.PkgName, n.PkgVersion, name)
+			firstErr = fmt.Errorf("%s/v%s/%s: %w", n.PkgName, n.PkgVersion, name, err)
 		}
 	}
 

--- a/gir/pkgconfig/pkgconfig.go
+++ b/gir/pkgconfig/pkgconfig.go
@@ -2,6 +2,7 @@
 package pkgconfig
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,8 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -22,7 +21,7 @@ var (
 func ensure() error {
 	pathOnce.Do(func() {
 		path, pathErr = exec.LookPath("pkg-config")
-		pathErr = errors.Wrap(pathErr, "failed to find pkg-config")
+		pathErr = fmt.Errorf("failed to find pkg-config: %w", pathErr)
 	})
 	return pathErr
 }
@@ -40,7 +39,7 @@ func IncludeDirs(pkgs ...string) ([]string, error) {
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
-			return nil, errors.Wrap(err, "pkg-config failed")
+			return nil, fmt.Errorf("pkg-config failed: %w", err)
 		}
 
 		return nil, fmt.Errorf(
@@ -56,7 +55,7 @@ func IncludeDirs(pkgs ...string) ([]string, error) {
 func FindGIRFiles(pkgs ...string) ([]string, error) {
 	includeDirs, err := IncludeDirs(pkgs...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to find include dirs")
+		return nil, fmt.Errorf("failed to find include dirs: %w", err)
 	}
 
 	var girFiles []string
@@ -82,7 +81,7 @@ func FindGIRFiles(pkgs ...string) ([]string, error) {
 		)
 
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to walk %q", baseDir)
+			return nil, fmt.Errorf("failed to walk %q: %w", baseDir, err)
 		}
 	}
 

--- a/gir/repository.go
+++ b/gir/repository.go
@@ -2,10 +2,9 @@ package gir
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // Repository represents a GObject Introspection Repository, which contains the
@@ -27,7 +26,7 @@ type Repository struct {
 func ParseRepository(file string) (*Repository, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open file")
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer f.Close()
 
@@ -39,7 +38,7 @@ func ParseRepositoryFromReader(r io.Reader) (*Repository, error) {
 	var repo Repository
 
 	if err := xml.NewDecoder(r).Decode(&repo); err != nil {
-		return nil, errors.Wrap(err, "failed to decode gir XML")
+		return nil, fmt.Errorf("failed to decode gir XML: %w", err)
 	}
 
 	return &repo, nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
-	github.com/pkg/errors v0.9.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This PR remove [github.com/pkg/errors](https://github.com/pkg/errors)

See [Working with Errors in Go 1.13](https://go.dev/blog/go1.13-errors)