### PR TITLE
Fix location of GIR files with root only subdirectories

### DIFF
--- a/gir/pkgconfig/pkgconfig.go
+++ b/gir/pkgconfig/pkgconfig.go
@@ -79,6 +79,10 @@ func FindGIRFiles(pkgs ...string) ([]string, error) {
 
 		err := fs.WalkDir(os.DirFS(baseDir), ".",
 			func(path string, d fs.DirEntry, err error) error {
+				if errors.Is(err, fs.ErrPermission) {
+					return fs.SkipDir
+				}
+
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Some subdirectories of my `/usr/` folder can not be opened without root permissions.
Therefore, the generation process fails with a permission denied error.
This patch instructs the generator to skip those directories.