### PR TITLE
More changes for generating gstreamer bindings

### DIFF
--- a/gir/girgen/cmt/cmt.go
+++ b/gir/girgen/cmt/cmt.go
@@ -56,11 +56,13 @@ type ParamDoc struct {
 // fields should rarely be used, because they're too magical. All fields inside
 // InfoFields are optional.
 type InfoFields struct {
-	Name       *string
-	Attrs      *gir.InfoAttrs
-	Elements   *gir.InfoElements
-	ParamDocs  []ParamDoc
-	ReturnDocs []ParamDoc
+	Name        *string
+	CType       *string
+	CIdentifier *string
+	Attrs       *gir.InfoAttrs
+	Elements    *gir.InfoElements
+	ParamDocs   []ParamDoc
+	ReturnDocs  []ParamDoc
 }
 
 func getField(value reflect.Value, field string) interface{} {
@@ -93,6 +95,15 @@ func GetInfoFields(v interface{}) InfoFields {
 	var inf InfoFields
 
 	inf.Name, _ = getField(value, "Name").(*string)
+	inf.CType, _ = getField(value, "CType").(*string)             // for types
+	inf.CIdentifier, _ = getField(value, "CIdentifier").(*string) // for constants
+	if inf.CIdentifier == nil && inf.CType == nil {
+		attrs, _ := getField(value, "CallableAttrs").(*gir.CallableAttrs) // for methods
+
+		if attrs != nil {
+			inf.CIdentifier = &attrs.CIdentifier
+		}
+	}
 	inf.Attrs, _ = getField(value, "InfoAttrs").(*gir.InfoAttrs)
 	inf.Elements, _ = getField(value, "InfoElements").(*gir.InfoElements)
 	inf.ParamDocs, _ = getField(value, "ParamDocs").([]ParamDoc)
@@ -213,10 +224,19 @@ func goDoc(v interface{}, indentLvl int, opts []Option) string {
 
 	var self string
 	var orig string
+	var cIdentifier string
 
 	if inf.Name != nil {
 		orig = *inf.Name
 		self = strcases.Go(orig)
+	}
+
+	if inf.CType != nil {
+		cIdentifier = *inf.CType
+	}
+
+	if inf.CIdentifier != nil {
+		cIdentifier = *inf.CIdentifier
 	}
 
 	var docBuilder strings.Builder
@@ -255,7 +275,7 @@ func goDoc(v interface{}, indentLvl int, opts []Option) string {
 
 	synopsize := searchOptsBool(opts, synopsize{})
 
-	docStr := FixGrammar(self, docBuilder.String(), append(opts, originalTypeName(orig))...)
+	docStr := fixGrammar(self, cIdentifier, docBuilder.String(), append(opts, originalTypeName(orig))...)
 	if synopsize && docStr == "" {
 		return ""
 	}
@@ -341,7 +361,7 @@ func writeParamDocs(tail *strings.Builder, label string, params []ParamDoc) {
 
 		var doc string
 		if param.InfoElements.Doc != nil {
-			doc = FixGrammar(name, param.InfoElements.Doc.String, originalTypeName(param.Name))
+			doc = fixGrammar(name, "", param.InfoElements.Doc.String, originalTypeName(param.Name))
 			// Insert a dash space into the lines.
 			doc = transformLines(doc, func(i, _ int, line string) string {
 				if i == 0 {
@@ -391,11 +411,15 @@ func trimFirstWord(paragraph string) string {
 	return parts[1]
 }
 
-// FixGrammar takes a comment and fixes its grammar by adding the [self] name
+// fixGrammar takes a comment and fixes its grammar by adding the [self] name
 // where appropriate to make it more idiomatic.
-func FixGrammar(self, cmt string, opts ...Option) string {
+func fixGrammar(self, cIdentifier, cmt string, opts ...Option) string {
 	if cmt == "" {
 		return ""
+	}
+
+	if cIdentifier != "" {
+		cIdentifier = " (" + cIdentifier + ")"
 	}
 
 	cmt = html.UnescapeString(cmt)
@@ -422,20 +446,20 @@ func FixGrammar(self, cmt string, opts ...Option) string {
 		switch {
 		case strings.EqualFold(firstWord, "is"), strings.EqualFold(firstWord, "will"):
 			// Turn "Will frob the fnord" into "{name} will frob the fnord".
-			cmt = self + " " + lowerFirstLetter(cmt)
+			cmt = self + cIdentifier + " " + lowerFirstLetter(cmt)
 		case strings.EqualFold(firstWord, "emitted"):
 			// Turn "emitted by Emitter" into "{name} is emitted by Emitter".
-			cmt = self + " is " + lowerFirstLetter(cmt)
+			cmt = self + cIdentifier + " is " + lowerFirstLetter(cmt)
 		case typeNamed, strings.HasPrefix(cmt, "#") && nthWord(cmt, 1) != "":
 			// Turn "#CName does stuff" into "GoName does stuff"
-			cmt = self + " " + trimFirstWord(cmt)
+			cmt = self + cIdentifier + " " + trimFirstWord(cmt)
 		case wordIsSimplePresent(firstWord):
 			// Turn "Frobs the fnord" into "{name} frobs the fnord".
-			cmt = self + " " + lowerFirstLetter(cmt)
+			cmt = self + cIdentifier + " " + lowerFirstLetter(cmt)
 		default:
 			// Trim the word "this" away to make the sentence gramatically
 			// correct.
-			cmt = self + ": " + lowerFirstLetter(strings.TrimPrefix(cmt, "this "))
+			cmt = self + cIdentifier + ": " + lowerFirstLetter(strings.TrimPrefix(cmt, "this "))
 		}
 	}
 

--- a/gir/girgen/file.go
+++ b/gir/girgen/file.go
@@ -216,6 +216,12 @@ func (f *GoFileGenerator) Generate() ([]byte, error) {
 			fpen.Words("// #cgo CFLAGS: -Wno-deprecated-declarations")
 		}
 
+		if defines := f.CDefines(); len(defines) > 0 {
+			for _, macro := range defines {
+				fpen.Linef("// #define %s", macro)
+			}
+		}
+
 		fpen.Words("// #include <stdlib.h>")
 		if incls := f.CIncludes(); len(incls) > 0 {
 			for _, incl := range incls {
@@ -315,6 +321,12 @@ func (f *GoFileGenerator) Pkgconfig() []string {
 // includes.
 func (f *GoFileGenerator) CIncludes() []string {
 	return namespaceCIncludes(f.current, &f.header)
+}
+
+// CIncludes returns this file's sorted C includes, including the repository's C
+// includes.
+func (f *GoFileGenerator) CDefines() []string {
+	return f.header.SortedCDefines()
 }
 
 func namespaceCIncludes(n *gir.NamespaceFindResult, h *file.Header) []string {

--- a/gir/girgen/file/file.go
+++ b/gir/girgen/file/file.go
@@ -54,6 +54,7 @@ type Header struct {
 	Marshalers     []Marshaler
 	Imports        map[string]string
 	CIncludes      map[string]struct{}
+	Defines        map[string]struct{}
 	Packages       map[string]struct{} // for pkg-config
 	Callbacks      map[string]struct{} // used for C blocks in general
 	CallbackDelete bool
@@ -271,6 +272,30 @@ func (h *Header) SortedCIncludes() []string {
 
 	sort.Strings(includes)
 	return includes
+}
+
+// DefineC defines a macro using #define
+func (h *Header) DefineC(macro string) {
+	if h.stop {
+		return
+	}
+
+	if h.Defines == nil {
+		h.Defines = map[string]struct{}{}
+	}
+
+	h.Defines[macro] = struct{}{}
+}
+
+// SortedCDefines returns the list of C defines sorted.
+func (h *Header) SortedCDefines() []string {
+	defines := make([]string, 0, len(h.Defines))
+	for macro := range h.Defines {
+		defines = append(defines, macro)
+	}
+
+	sort.Strings(defines)
+	return defines
 }
 
 // NeedsGLibObject adds the glib-object.h include and the glib-2.0 package.

--- a/gir/girgen/generators/class-interface.go
+++ b/gir/girgen/generators/class-interface.go
@@ -68,22 +68,14 @@ var classInterfaceTmpl = gotmpl.NewGoTemplate(`
 
 	{{ $needsPrivate := false }}
 
-	{{ if .Abstract }}
-
-	{{ if .IsClass }}
-	// {{ .InterfaceName }} describes types inherited from class {{ .StructName }}.
-	{{ $needsPrivate = true -}}
+	// {{ .InterfaceName }} describes types inherited from {{ .StructName }}.
 	//
 	// To get the original type, the caller must assert this to an interface or
 	// another type.
 	type {{ .InterfaceName }} interface {
-		coreglib.Objector
-		base{{ .StructName }}() *{{ .StructName }}
-	}
-	{{ else }}
-	// {{ .InterfaceName }} describes {{ .StructName }}'s interface methods.
-	type {{ .InterfaceName }} interface {
-		coreglib.Objector
+		{{- range .ParentNames }}
+		{{ . }}
+		{{- end }}
 
 		{{ if .Methods -}}
 
@@ -101,15 +93,13 @@ var classInterfaceTmpl = gotmpl.NewGoTemplate(`
 
 		{{- end}}
 
-		{{ if not .Methods -}}
+		{{ if or (not .Methods) .IsClass -}}
 		{{ $needsPrivate = true -}}
 		base{{ .StructName }}() *{{ .StructName }}
 		{{ end -}}
 	}
-	{{ end }}
 
 	var _ {{ .InterfaceName }} = (*{{ .StructName }})(nil)
-	{{ end }}
 
 	{{ if .GLibTypeStruct }}
 	{{ if .IsClass }}

--- a/gir/girgen/generators/class-interface.go
+++ b/gir/girgen/generators/class-interface.go
@@ -80,10 +80,8 @@ var classInterfaceTmpl = gotmpl.NewGoTemplate(`
 		{{ if .Methods -}}
 
 		{{ range .Methods }}
-		{{ if $.IsInSameFile . -}}
-		{{- Synopsis . 1 TrailingNewLine }}
+		{{ Synopsis . 1 TrailingNewLine }}
 		{{- .Name }}{{ .Tail }}
-		{{- end }}
 		{{- end }}
 
 		{{ range .Signals }}

--- a/gir/girgen/generators/iface/iface.go
+++ b/gir/girgen/generators/iface/iface.go
@@ -338,6 +338,12 @@ func (g *Generator) Use(typ interface{}) bool {
 	}
 
 	for i, sig := range signals {
+		// signals with the G_SIGNAL_ACTION flag are there to be freely emitted by user code. They also can
+		// be thought of as methods on generic objects.
+		if sig.Action {
+			continue // TODO: generate a type safe call for emit instead, similar to how we do for connect
+		}
+
 		// A signal has 2 implied parameters: the instance (0th) parameter and
 		// the final user_data parameter.
 		param := &gir.Parameters{

--- a/gir/girgen/generators/iface/iface.go
+++ b/gir/girgen/generators/iface/iface.go
@@ -486,6 +486,21 @@ func (g *Generator) ImplInterfaces() []string {
 	return names
 }
 
+func (g *Generator) ParentNames() []string {
+	parents := g.Tree.Requires
+	names := make([]string, len(parents))
+
+	for i, parent := range parents {
+		namespace := parent.NeedsNamespace(g.gen.Namespace())
+		if namespace {
+			parent.ImportPubl(g.gen, &g.header)
+		}
+		names[i] = parent.PublicType(namespace)
+	}
+
+	return names
+}
+
 // IsInSameFile returns true if the given GIR item is in the same file. It's
 // guessed using the InfoElements field in the given value.
 func (g *Generator) IsInSameFile(v interface{}) bool {

--- a/gir/girgen/types/filter.go
+++ b/gir/girgen/types/filter.go
@@ -143,27 +143,42 @@ func PreserveGetName(girType string) Preprocessor {
 	})
 }
 
-// RenameEnumMembers renames all members of the matched enums. It is primarily
+// RenameEnumMembers renames the c-identifier of members of the matched enum or bitfield. It is primarily
 // used to avoid collisions.
 func RenameEnumMembers(enum, regex, replace string) Preprocessor {
 	girTypeMustBeVersioned(enum)
 	re := regexp.MustCompile(regex)
+	return MapMembers(enum, func(member gir.Member) gir.Member {
+		parts := strings.SplitN(member.CIdentifier, "_", 2)
+		parts[1] = re.ReplaceAllString(parts[1], replace)
+		member.CIdentifier = parts[0] + "_" + parts[1]
+
+		return member
+	})
+}
+
+// MapMembers allows you to freely change any property of the members of the given enum or bitfield type.
+// it can be used to fix faulty girs, but also to change the behavior of the generator.
+func MapMembers(enumOrBitfieldType string, fn func(member gir.Member) gir.Member) Preprocessor {
+	girTypeMustBeVersioned(enumOrBitfieldType)
 	return PreprocessorFunc(func(repos gir.Repositories) {
-		result := repos.FindFullType(enum)
+		result := repos.FindFullType(enumOrBitfieldType)
 		if result == nil {
-			log.Printf("GIR enum %q not found", enum)
+			log.Panicf("GIR enum or bitfield %q not found", enumOrBitfieldType)
 			return
 		}
 
-		enum, ok := result.Type.(*gir.Enum)
-		if !ok {
-			log.Panicf("GIR type %T is not enum", result.Type)
-		}
-
-		for i, member := range enum.Members {
-			parts := strings.SplitN(member.CIdentifier, "_", 2)
-			parts[1] = re.ReplaceAllString(parts[1], replace)
-			enum.Members[i].CIdentifier = parts[0] + "_" + parts[1]
+		switch v := result.Type.(type) {
+		case *gir.Enum:
+			for i, member := range v.Members {
+				v.Members[i] = fn(member)
+			}
+		case *gir.Bitfield:
+			for i, member := range v.Members {
+				v.Members[i] = fn(member)
+			}
+		default:
+			log.Panicf("GIR type %T is not enum or bitfield", result.Type)
 		}
 	})
 }

--- a/gir/girgen/types/typeconv/c-go.go
+++ b/gir/girgen/types/typeconv/c-go.go
@@ -445,6 +445,53 @@ func (conv *Converter) cgoConverter(value *ValueConverted) bool {
 		}
 		return true
 
+	case "Gst.MiniObject", "Gst.Structure", "Gst.Caps", "Gst.Buffer", "Gst.BufferList", "Gst.Memory", "Gst.Message", "Gst.Query", "Gst.Sample":
+		value.header.Import("runtime")
+		value.header.Import("unsafe")
+		value.header.ImportCore("gextras")
+
+		// Require 1 pointer to avoid weird copies.
+		value.vtmpl(`
+			<.Out.Set> = <.OutCast 1>(gextras.NewStructNative(unsafe.Pointer(<.InNamePtr 1>)))
+		`)
+		if value.fail {
+			value.Logln(logger.Debug, "record set fail")
+			return false
+		}
+
+		if value.TransferOwnership.TransferOwnership == "none" {
+			value.vtmpl("C.gst_mini_object_ref((*C.GstMiniObject)(unsafe.Pointer(<.InNamePtr 1>)))")
+		}
+
+		if value.TransferOwnership.TransferOwnership != "borrow" {
+			value.vtmpl(`
+				runtime.SetFinalizer(
+					gextras.StructIntern(unsafe.Pointer(<.OutInPtr 1><.OutName>)),
+					func(intern *struct{ C unsafe.Pointer }) {
+						C.gst_mini_object_unref((*C.GstMiniObject)(intern.C))
+					})
+			`)
+		}
+
+		if value.TransferOwnership.TransferOwnership == "borrow" && len(conv.Results) == 0 {
+			panic("result should borrow even though callable has no param")
+		}
+
+		if value.TransferOwnership.TransferOwnership == "borrow" {
+			// the returned value must keep the instance alive, which is the first passed param, aka the receiver
+			value.vtmpl(fmt.Sprintf(`
+				runtime.SetFinalizer( // value is borrowed, don't clean up the receiver until dropped
+					gextras.StructIntern(unsafe.Pointer(<.OutInPtr 1><.OutName>)),
+					func(_ *struct{ C unsafe.Pointer }) {
+						runtime.KeepAlive(%s)
+					},
+				)`,
+				conv.Results[0].InName,
+			))
+		}
+
+		return true
+
 	case "GObject.Object", "GObject.InitiallyUnowned":
 		return value.cgoSetObject(conv)
 

--- a/gir/girgen/types/typeconv/go-c.go
+++ b/gir/girgen/types/typeconv/go-c.go
@@ -479,7 +479,7 @@ func (conv *Converter) gocConverter(value *ValueConverted) bool {
 
 		value.header.NeedsExternGLib()
 		value.p.Linef(
-			"%s = (*C.GClosure)(coreglib.NewClosure(coreglib.InternObject(%s), %s))",
+			"%s = (*C.GClosure)(coreglib.NewClosure(coreglib.BaseObject(%s), %s))",
 			value.Out.Set, instance.In.Name, value.In.Name,
 		)
 
@@ -605,7 +605,7 @@ func (conv *Converter) gocConverter(value *ValueConverted) bool {
 		value.header.Import("unsafe")
 		value.header.NeedsExternGLib()
 		value.p.Linef(
-			"%s = %s(unsafe.Pointer(coreglib.InternObject(%s).Native()))",
+			"%s = %s(unsafe.Pointer(coreglib.BaseObject(%s).Native()))",
 			value.Out.Set, value.OutCast(1), value.InNamePtrPubl(1),
 		)
 
@@ -613,7 +613,7 @@ func (conv *Converter) gocConverter(value *ValueConverted) bool {
 			// Caller is taking ownership, which means it will steal our
 			// reference. Ensure that we take our own.
 			value.p.Linef(
-				"C.g_object_ref(C.gpointer(coreglib.InternObject(%s).Native()))",
+				"C.g_object_ref(C.gpointer(coreglib.BaseObject(%s).Native()))",
 				value.InNamePtrPubl(1),
 			)
 		}


### PR DESCRIPTION
I got some closure name collisions for the generated Connect callbacks. The collisions only happened on action signals which are only to be emitted AFAIK (please verify).

I also needed to preprocess enum member names so I added a set name.