### PR TITLE
feat: add ListModel.Update for in-place item replacement

### DIFF
--- a/pkg/core/gbox/box.go
+++ b/pkg/core/gbox/box.go
@@ -101,6 +101,11 @@ func Get(ptr uintptr) interface{} {
 	return registry.Get(ptr - minLegalPointer)
 }
 
+// Update replaces the value at the given fake pointer without changing its slot.
+func Update(ptr uintptr, v interface{}) {
+	registry.Set(ptr-minLegalPointer, v)
+}
+
 // Delete deletes a boxed value. It is exposed to C under the name
 // "callbackDelete".
 func Delete(ptr uintptr) {

--- a/pkg/core/gioutil/listmodel.c
+++ b/pkg/core/gioutil/listmodel.c
@@ -132,6 +132,13 @@ void gotk4_gbox_list_append(Gotk4GboxList *self, guintptr id) {
   g_list_model_items_changed(G_LIST_MODEL(self), objects_get_size(&self->items) - 1, 0, 1);
 }
 
+void gotk4_gbox_list_update_item(Gotk4GboxList *self, guint position) {
+  g_return_if_fail(GOTK4_IS_GBOX_LIST(self));
+  g_return_if_fail(position < objects_get_size(&self->items));
+
+  g_list_model_items_changed(G_LIST_MODEL(self), position, 1, 1);
+}
+
 guintptr gotk4_gbox_list_get_id(Gotk4GboxList *self, guint position) {
   g_return_val_if_fail(GOTK4_IS_GBOX_LIST(self), 0);
   g_return_val_if_fail(position < objects_get_size(&self->items), 0);

--- a/pkg/core/gioutil/listmodel.go
+++ b/pkg/core/gioutil/listmodel.go
@@ -91,6 +91,15 @@ func (l *ListModel[T]) At(index int) T {
 	return gbox.Get(id).(T)
 }
 
+// Update replaces the value at the given index without destroying and
+// recreating the underlying GObject. It notifies the model so GTK
+// rebinds any visible cells.
+func (l *ListModel[T]) Update(index int, v T) {
+	id := uintptr(C.gotk4_gbox_list_get_id(l.native(), C.guint(index)))
+	gbox.Update(id, v)
+	C.gotk4_gbox_list_update_item(l.native(), C.guint(index))
+}
+
 // Len returns the number of items in the list.
 func (l *ListModel[T]) Len() int {
 	return int(l.ListModel.NItems())

--- a/pkg/core/gioutil/listmodel.h
+++ b/pkg/core/gioutil/listmodel.h
@@ -24,6 +24,7 @@ Gotk4GboxList *gotk4_gbox_list_new(void);
 void gotk4_gbox_list_splice(Gotk4GboxList *self, guint position, guint n_removals,
                             guintptr *additions);
 void gotk4_gbox_list_append(Gotk4GboxList *self, guintptr id);
+void gotk4_gbox_list_update_item(Gotk4GboxList *self, guint position);
 guintptr gotk4_gbox_list_get_id(Gotk4GboxList *self, guint position);
 
 G_END_DECLS

--- a/pkg/core/slab/slab.go
+++ b/pkg/core/slab/slab.go
@@ -121,9 +121,18 @@ func (s *Slab) Delete(i uintptr) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Perform simple bound check.
 	if i < uintptr(len(s.list)) {
 		s.list[i] = slabEntry{atomic.Value{}, s.free, false}
 		s.free = i
+	}
+}
+
+// Set replaces the entry at the given index without affecting the free list.
+func (s *Slab) Set(i uintptr, entry interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if i < uintptr(len(s.list)) {
+		s.list[i].Value.Store(entry)
 	}
 }


### PR DESCRIPTION
## Description

Adds `ListModel.Update(index, val)` to allow updating list model items in-place without destroying and recreating the underlying GObjects.
This avoids allocation churn when refreshing list data on timers.

### Changes

- `slab.Set` — replace a slab entry without affecting the free list
- `gbox.Update` — update a gbox value in-place by its ID
- `ListModel.Update` — update an item + emit `items-changed(1,1)` so GTK rebinds
- `gotk4_gbox_list_update_item` — C helper to emit the items-changed signal
