### PR TITLE
Fixing some problems with subclassing

### DIFF
--- a/pkg/core/glib/go.go
+++ b/pkg/core/glib/go.go
@@ -564,17 +564,22 @@ func Overrides[OverridesT any](obj Objector) OverridesT {
 	rtype := rtypeElemV(obj)
 
 	if subclass, ok := knownTypes[rtype]; ok {
-		topt, ok := subclass.opts.typeOpts[subclass.parentType]
-		if ok && topt.override != nil {
-			overrides, ok := topt.override(obj).(OverridesT)
-			if ok {
-				return overrides
-			}
+		otype := rtypeElem[OverridesT]()
 
-			var z OverridesT
-			log.Panicf(
-				"gotk4: Overrides: object type %s's parent overrides type is %s, cannot assert to %T",
-				rtype, subclass.parentType.GoOverridesType, z)
+		ptype, ok := classOverridesTypes[otype]
+		if ok {
+			topt, ok := subclass.opts.typeOpts[ptype]
+			if ok && topt.override != nil {
+				overrides, ok := topt.override(obj).(OverridesT)
+				if ok {
+					return overrides
+				}
+
+				var z OverridesT
+				log.Panicf(
+					"gotk4: Overrides: object type %s's parent overrides type is %s, cannot assert to %T",
+					rtype, subclass.parentType.GoOverridesType, z)
+			}
 		}
 
 		var z OverridesT
@@ -713,7 +718,15 @@ func RegisterClassInfo[InstanceT Objector, ClassT, OverridesT any](
 		GoOverridesType: rtypeElem[OverridesT](),
 		InitClass: func(gclass unsafe.Pointer, overridesV, initFuncV any) {
 			overrides, _ := overridesV.(OverridesT)
-			initFunc, _ := initFuncV.(func(ClassT))
+			var initFunc func(ClassT)
+
+			initFuncA, ok := initFuncV.(func(any))
+			if ok {
+				initFunc = func(class ClassT) {
+					initFuncA(class)
+				}
+			}
+
 			initClassFunc(gclass, overrides, initFunc)
 		},
 		WrapClass: func(obj *Object) Objector {
@@ -797,7 +810,9 @@ func _gotk4_gobject_init_class(gclass, data C.gpointer) {
 
 		var overrides any
 		if topt.override != nil {
-			overrides = topt.override(nil)
+			value := reflect.New(subclass.goType)
+			vinf := value.Interface().(Objector)
+			overrides = topt.override(vinf)
 		}
 
 		parentType.InitClass(unsafe.Pointer(gclass), overrides, topt.classInit)


### PR DESCRIPTION
I'm currently interested in using UI templates with gotk4 to improve my UI code, and I realized that the subclassing features already existed in core/glib but there were a few things that weren't working, so I put in a few tests to get them more rounded out.

This (potentially) fixes issues:
https://github.com/diamondburned/gotk4/issues/22
https://github.com/diamondburned/gotk4/issues/113
https://github.com/diamondburned/gotk4/issues/157

Here's an example of it working:

<img width="1307" height="804" alt="Screenshot from 2026-07-31 21-23-28" src="https://github.com/user-attachments/assets/e872d98a-14d6-49b6-87ba-34f6ac94b32a" />

The reason the example code is so weird is because I was trying to make it generic but I gave up lol. I'll likely try again later. I don't this is 100% yet, but it should help nonetheless!

Using `CC=clang go build [...]` helped out my build times tremendously. It's the only way I was able to get this done at all.